### PR TITLE
Line feature not serialized correctly 

### DIFF
--- a/lib/src/models/geoserie.dart
+++ b/lib/src/models/geoserie.dart
@@ -132,13 +132,13 @@ class GeoSerie {
       extra1 = "[";
       extra2 = "]";
     }
-    return '[{"type":"Feature","properties":{"name":"$name"}, '
+    return '{"type":"Feature","properties":{"name":"$name"}, '
             '"geometry":{"type":"$type",'
             '"coordinates":' +
         extra1 +
         toGeoJsonCoordinatesString() +
         extra2 +
-        '}}]';
+        '}}';
   }
 
   GeoSerieType _typeFromString(String typeStr) {


### PR DESCRIPTION
The extra pair of `[]` breaks the geojson structure and makes it impossible to deserialize the objects back from json.