### PR TITLE
Replaced latlong with latlong2

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -1,5 +1,5 @@
 import 'package:geopoint/geopoint.dart';
-import 'package:latlong/latlong.dart';
+import 'package:latlong2/latlong.dart';
 
 class Place {
   Place(this.name, this.point);

--- a/lib/src/models/geopoint.dart
+++ b/lib/src/models/geopoint.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:latlong/latlong.dart';
+import 'package:latlong2/latlong.dart';
 import 'package:meta/meta.dart';
 import 'package:slugify2/slugify.dart';
 

--- a/lib/src/models/geoserie.dart
+++ b/lib/src/models/geoserie.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:latlong/latlong.dart';
+import 'package:latlong2/latlong.dart';
 import 'package:meta/meta.dart';
 import 'geopoint.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   extra_pedantic: ^1.2.0
-  latlong: ^0.6.1
+  latlong2: ^0.8.0
   meta: ^1.1.8
   pedantic: ^1.9.2
   slugify2: ^0.2.1

--- a/test/geopoint_test.dart
+++ b/test/geopoint_test.dart
@@ -1,6 +1,6 @@
 import "package:test/test.dart";
 import 'package:geopoint/geopoint.dart';
-import 'package:latlong/latlong.dart';
+import 'package:latlong2/latlong.dart';
 
 void main() {
   final ts = DateTime.now().millisecondsSinceEpoch;

--- a/test/geoserie_test.dart
+++ b/test/geoserie_test.dart
@@ -1,6 +1,6 @@
 import "package:test/test.dart";
 import 'package:geopoint/geopoint.dart';
-import 'package:latlong/latlong.dart';
+import 'package:latlong2/latlong.dart';
 
 void main() {
   final geoPoints = <GeoPoint>[


### PR DESCRIPTION
I find it neccessary to use [latlong2](https://github.com/jifalops/dart-latlong) instead of [latlong](https://github.com/MikeMitterer/dart-latlong) as the latter isn't mantained anymore.
In particular I'm having trouble to resolve dependencies given that latlong uses `logging: '>=0.11.3 <1.0.0'` and pretty much everything now uses `logging: ^1.0.0` or higher.
As an example, [flutter_map](https://github.com/fleaflet/flutter_map/commit/54f891e831ca69437f46ff8998b5c50a570e069b) is also moving on to using latlong2.
All test pass so everything should be ok. 💯 