### PR TITLE
use null safe versions of dependencies

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -1,5 +1,5 @@
 import 'package:geopoint/geopoint.dart';
-import 'package:latlong/latlong.dart';
+import 'package:latlong2/latlong.dart';
 
 class Place {
   Place(this.name, this.point);

--- a/lib/src/models/geopoint.dart
+++ b/lib/src/models/geopoint.dart
@@ -1,10 +1,8 @@
 import 'dart:io';
 
-import 'package:latlong/latlong.dart';
+import 'package:latlong2/latlong.dart';
 import 'package:meta/meta.dart';
-import 'package:slugify2/slugify.dart';
-
-var _slugify = Slugify();
+import 'package:slugify/slugify.dart';
 
 /// A class to hold geopoint data structure
 class GeoPoint {
@@ -32,7 +30,7 @@ class GeoPoint {
       this.images})
       : assert(latitude != null),
         assert(longitude != null) {
-    if (slug == null && name != null) slug = _slugify.slugify(name);
+    if (slug == null && name != null) slug = slugify(name);
   }
 
   /// The name of the geopoint
@@ -123,7 +121,7 @@ class GeoPoint {
         region = "${json["region"]}",
         country = "${json["country"]}" {
     if (slug == null && name != null) {
-      slug = _slugify.slugify("${json["name"]}");
+      slug = slugify("${json["name"]}");
     }
   }
 
@@ -134,7 +132,7 @@ class GeoPoint {
   GeoPoint.fromLatLng({@required LatLng point, this.name})
       : latitude = point.latitude,
         longitude = point.longitude {
-    if (name != null) slug = _slugify.slugify(name);
+    if (name != null) slug = slugify(name);
   }
 
   /// Get a json map from this geopoint

--- a/lib/src/models/geoserie.dart
+++ b/lib/src/models/geoserie.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:latlong/latlong.dart';
+import 'package:latlong2/latlong.dart';
 import 'package:meta/meta.dart';
 import 'geopoint.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,11 +7,11 @@ environment:
   sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
-  extra_pedantic: ^1.2.0
+  extra_pedantic: ^1.5.0
   latlong2: ^0.8.0
-  meta: ^1.1.8
-  pedantic: ^1.9.2
-  slugify2: ^0.2.1
+  meta: ^1.4.0
+  pedantic: ^1.11.0
+  slugify: ^2.0.0
 
 dev_dependencies:
   test: ^1.6.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,11 +4,11 @@ homepage: https://github.com/synw/geopoint
 version: 0.8.0
 
 environment:
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
   extra_pedantic: ^1.2.0
-  latlong: ^0.6.1
+  latlong2: ^0.8.0
   meta: ^1.1.8
   pedantic: ^1.9.2
   slugify2: ^0.2.1


### PR DESCRIPTION
flutter_map is preparing a null safe version: https://github.com/fleaflet/flutter_map/pull/870
It can already be used: https://github.com/fleaflet/flutter_map/pull/870

I am already using the null safe version. Unfortunately map_controller is not null safe yet. And it depends on geopoint.

So this pull request aims to make geopoint null safe. To then enable map_controller to become null safe.

Warning: I am a flutter noob (JavaScript dev). And could not test this as my library that depends on it (map_controller) can not be altered to use a git dependency (or so flutter tells me). So feel free to change this pull request as much as you like. Or simply close it and solve it better.

Relates to https://github.com/synw/geopoint/issues/6 and encompasses https://github.com/synw/geopoint/pull/5.

More changes are needed to make the code itself null safe: https://dart.dev/null-safety/migration-guide#step2-migrate. Unfortunately I don't feel up to knowing enough about this library's code to do that.